### PR TITLE
chore: Only run certain actions when significant changes are made

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   build-pr:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'team-modern-deployments-bot' }}
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login != 'team-modern-deployments-bot'}}
     permissions: # https://github.com/dorny/test-reporter/issues/168
       statuses: write
       checks: write
@@ -18,26 +18,39 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
+      - name: Check for significant changes
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v45
+        with:
+          files_ignore: |
+            .release-please-manifest.json
+            release-please-config.json
+            .github/**
+            **.md
       - name: Set short git commit SHA
         id: commit_sha
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.sha }})
           echo "SHORT_SHA=$calculatedSha" >> $GITHUB_OUTPUT
       - name: Determine version
         id: version
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         run: |
           BRANCH_NAME=$(echo ${{ github.head_ref }} | tr '/' '-' | tr '_' '-')
           CURRENT_VERSION=$(git describe --tags --abbrev=0 || echo "0.0.0")
           VERSION="${CURRENT_VERSION}-${BRANCH_NAME}-${{ steps.commit_sha.outputs.SHORT_SHA }}"
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
       - name: Build csharp sdk debug
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         run: dotnet pack lib/csharp/Octopus/Octopus.Kubernetes.Monitor.MessageContracts --configuration Debug /p:Version=${{ steps.version.outputs.VERSION }} --output .
       - name: Publish to feedz
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
         run: dotnet nuget push Octopus.Kubernetes.Monitor.MessageContracts.${{ steps.version.outputs.VERSION }}.nupkg --source https://f.feedz.io/octopus-deploy/dependencies/nuget/index.json --api-key ${{secrets.FEEDZ_API_KEY}}
 
   build-release:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'csharp-sdk') }}
+    if: ${{ github.event_name == 'release' && startsWith(github.event.release.tag_name, 'csharp-sdk')}}
     permissions: # https://github.com/dorny/test-reporter/issues/168
       statuses: write
       checks: write

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -16,7 +16,14 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+            - name: Check for significant changes
+              id: changed-files-specific
+              uses: tj-actions/changed-files@v45
+              with:
+                files: |
+                  **.proto
             - name: Buf 
+              if: steps.changed-files-specific.outputs.any_changed == 'true'
               uses: bufbuild/buf-action@v1
               with: 
                 push: false


### PR DESCRIPTION
Stops building and pushing of branch builds if there hasn't been any significant changes made e.g. No changes to protos or SDKs