### PR TITLE
chore: Added root module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/OctopusDeploy/kubernetes-monitor-contracts
+
+go 1.24


### PR DESCRIPTION
Go isn't liking that there isn't a root module and is preventing installing the package as `github.com/OctopusDeploy/kubernetes-monitor-contracts` 